### PR TITLE
Fix current_item_count counter for DoctrineODMMongoDBAdapt

### DIFF
--- a/src/Bgy/PaginatedResource/Resource/PagerfantaResource.php
+++ b/src/Bgy/PaginatedResource/Resource/PagerfantaResource.php
@@ -35,7 +35,7 @@ class PagerfantaResource extends AbstractResource
                 $paginator->getNbPages(),
                 $paginator->getMaxPerPage(),
                 $paginator->getCurrentPage(),
-                count($paginator->getIterator())
+                count($collection)
             )
         );
     }


### PR DESCRIPTION
Hello. For some AdapterInterface of Pagerfanta counter doesn't work correctly. For example  https://github.com/whiteoctober/Pagerfanta/blob/master/src/Pagerfanta/Adapter/DoctrineODMMongoDBAdapter.php. Method `count($paginator->getIterator())`  doesn't return length current page, because it return length of all results (ignore limit and skip) . Details here: https://github.com/doctrine/mongodb-odm/issues/298.
p.s. I'm sorry for my english
